### PR TITLE
Fail fast once operation has reached terminal state

### DIFF
--- a/c8y_test_core/assert_operation.py
+++ b/c8y_test_core/assert_operation.py
@@ -78,15 +78,18 @@ class AssertOperation:
             raise
 
         if failure_reason is not None:
-            assert (
-                "failureReason" in self.operation
-            ), "failureReason is mandatory when setting to FAILED"
-            actual_failure_reason = self.operation.to_json().get("failureReason")
-            assert actual_failure_reason == compare.RegexPattern(failure_reason), (
-                "Failure reason does not match regex pattern\n"
-                f"got: {actual_failure_reason}\n"
-                f"wanted: {failure_reason}"
-            )
+            try:
+                assert (
+                    "failureReason" in self.operation
+                ), "failureReason is mandatory when setting to FAILED"
+                actual_failure_reason = self.operation.to_json().get("failureReason")
+                assert actual_failure_reason == compare.RegexPattern(failure_reason), (
+                    "Failure reason does not match regex pattern\n"
+                    f"got: {actual_failure_reason}\n"
+                    f"wanted: {failure_reason}"
+                )
+            except AssertionError as ex:
+                raise FinalAssertionError(ex)
         return self.operation
 
     def assert_done(self, **kwargs) -> Operation:


### PR DESCRIPTION
This changes failure reason assertions to always be final, as once the operation is in a terminal state, the failure reason should never change.