### PR TITLE
fix(software): use softwareType property rather than type

### DIFF
--- a/c8y_test_core/assert_software_management.py
+++ b/c8y_test_core/assert_software_management.py
@@ -39,9 +39,7 @@ class SoftwareManagement(AssertDevice):
         fragments = {
             "description": "Update software: "
             + ",".join(software.name for software in software_list),
-            "c8y_SoftwareUpdate": [
-                software.to_update_format() for software in software_list
-            ],
+            "c8y_SoftwareUpdate": [software.to_dict() for software in software_list],
             **kwargs,
         }
         return self._execute(**fragments)
@@ -59,7 +57,7 @@ class SoftwareManagement(AssertDevice):
             "description": "Install software: "
             + ",".join(software.name for software in software_list),
             "c8y_SoftwareList": [
-                {**software.to_update_format(), "action": self.Action.INSTALL}
+                {**software.to_dict(), "action": self.Action.INSTALL}
                 for software in software_list
             ],
             **kwargs,

--- a/c8y_test_core/assert_software_management.py
+++ b/c8y_test_core/assert_software_management.py
@@ -115,11 +115,11 @@ class SoftwareManagement(AssertDevice):
                     errors.append((exp_software.name, self.Reasons.VERSION_MISMATCH))
 
             # type check
-            if exp_software.type:
-                type_pattern = re.compile(exp_software.type)
+            if exp_software.softwareType:
+                type_pattern = re.compile(exp_software.softwareType)
                 for current_software in mo["c8y_SoftwareList"]:
                     name = current_software.get("name", "")
-                    software_type = current_software.get("type", "")
+                    software_type = current_software.get("softwareType", "")
                     if name == exp_software.name and type_pattern.match(software_type):
                         break
                 else:

--- a/c8y_test_core/models.py
+++ b/c8y_test_core/models.py
@@ -34,13 +34,9 @@ class Software:
             return compare_dataclass(self, obj)
         return compare_dataclass(self, Software(**obj))
 
-    def to_update_format(self) -> Dict[str, str]:
-        """Return software item in the format expected by the
-        c8y_SoftwareUpdate operation
-        """
-        value = self.__dict__
-        value["softwareType"] = value.pop("type", "")
-        return value
+    def to_dict(self) -> Dict[str, str]:
+        """Return software item as a dictionary"""
+        return self.__dict__
 
 
 @dataclasses.dataclass

--- a/c8y_test_core/models.py
+++ b/c8y_test_core/models.py
@@ -27,7 +27,7 @@ class Software:
     version: str = ""
     url: str = ""
     action: str = ""
-    type: str = ""
+    softwareType: str = ""
 
     def __eq__(self, obj: object) -> bool:
         if isinstance(obj, Software):

--- a/tests/test_software.py
+++ b/tests/test_software.py
@@ -67,18 +67,20 @@ class TestSoftwareInstalled(unittest.TestCase):
     def test_package_is_installed_match_by_type(self):
         mo = create_mo_with_software(
             [
-                {"name": "package1", "version": "1.0.0", "type": "apt"},
+                {"name": "package1", "version": "1.0.0", "softwareType": "apt"},
             ]
         )
         self.software.assert_software_installed(
-            Software("package1", version=r"1\.[0-9]+\.[0-9]", type="apt"),
+            Software("package1", version=r"1\.[0-9]+\.[0-9]", softwareType="apt"),
             mo=mo,
             timeout=0.01,
         )
 
         with self.assertRaisesRegex(AssertionError, "TYPE_MATCH"):
             self.software.assert_software_installed(
-                Software("package1", version=r"1\.[0-9]+\.[0-9]", type="debian"),
+                Software(
+                    "package1", version=r"1\.[0-9]+\.[0-9]", softwareType="debian"
+                ),
                 mo=mo,
                 timeout=0.01,
             )


### PR DESCRIPTION
A mistake in the interpretation of the Cumulocity IoT spec lead to using the wrong software type property `type` instead of the correct `softwareType`