### PR TITLE
fix: inventory fragment value assertion

### DIFF
--- a/c8y_test_core/assert_inventory.py
+++ b/c8y_test_core/assert_inventory.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List
 from c8y_api.model import ManagedObject
 from c8y_test_core.assert_device import AssertDevice
 from c8y_test_core.compare import compare_dataclass
+from c8y_test_core.errors import FinalAssertionError
 
 
 log = logging.getLogger()
@@ -114,6 +115,12 @@ class AssertInventory(AssertDevice):
         """Assert the present and the values of fragments in the device managed object"""
         if mo is None:
             mo = self.context.client.inventory.get(self.context.device_id)
+
+        if not fragments:
+            raise FinalAssertionError(
+                "At least 1 fragment is required to compare objects"
+            )
+
         assert compare_dataclass(mo.to_json(), fragments), (
             "Managed object does not contain fragment values\n"
             f"  wanted={fragments}\n"

--- a/c8y_test_core/compare.py
+++ b/c8y_test_core/compare.py
@@ -30,6 +30,8 @@ def compare_dataclass(obj1: object, obj2: object) -> bool:
         if isinstance(value, re.Pattern):
             if not re.match(value, obj1_dict.get(key, "")):
                 return False
+        elif isinstance(value, dict):
+            return compare_dataclass(obj1_dict.get(key, ""), value)
         else:
             if value != obj1_dict.get(key, ""):
                 return False

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -1,0 +1,183 @@
+"""Compare tests
+"""
+import unittest
+from c8y_test_core.compare import compare_dataclass
+import re
+
+
+class TestDataclassComparison(unittest.TestCase):
+    def setUp(self) -> None:
+        return super().setUp()
+
+    def test_compare_objects(self):
+        mo = {
+            "type": "thin-edge.io",
+            "name": "TST_run_brass_click",
+            "owner": "device_TST_run_brass_click",
+            "c8y_Agent": {
+                "name": "thin-edge.io",
+                "version": "1.1.2~154+gc1df00f",
+                "url": "https://thin-edge.io",
+            },
+            "c8y_Availability": {
+                "lastMessage": "2024-06-25T15:13:38.919Z",
+                "status": "AVAILABLE",
+            },
+            "com_cumulocity_model_Agent": {},
+            "c8y_IsDevice": {},
+            "c8y_Connection": {"status": "CONNECTED"},
+            "c8y_RequiredAvailability": {"responseInterval": 1},
+            "c8y_SupportedOperations": [
+                "c8y_DownloadConfigFile",
+                "c8y_LogfileRequest",
+                "c8y_RemoteAccessConnect",
+                "c8y_Restart",
+                "c8y_SoftwareUpdate",
+                "c8y_UploadConfigFile",
+            ],
+            "c8y_SoftwareList": [
+                {"softwareType": "apt", "name": "apt", "version": "2.6.1", "url": ""},
+                {
+                    "softwareType": "apt",
+                    "name": "apt-transport-https",
+                    "version": "2.6.1",
+                    "url": "",
+                },
+                {
+                    "softwareType": "apt",
+                    "name": "c8y-firmware-plugin",
+                    "version": "1.1.2~154+gc1df00f",
+                    "url": "",
+                },
+                {
+                    "softwareType": "apt",
+                    "name": "c8y-remote-access-plugin",
+                    "version": "1.1.2~154+gc1df00f",
+                    "url": "",
+                },
+                {
+                    "softwareType": "apt",
+                    "name": "curl",
+                    "version": "7.88.1-10+deb12u5",
+                    "url": "",
+                },
+                {
+                    "softwareType": "apt",
+                    "name": "mosquitto",
+                    "version": "2.0.18-1+b2",
+                    "url": "",
+                },
+                {
+                    "softwareType": "apt",
+                    "name": "mosquitto-clients",
+                    "version": "2.0.18-1+b2",
+                    "url": "",
+                },
+                {
+                    "softwareType": "apt",
+                    "name": "ssh",
+                    "version": "1:9.7p1-5",
+                    "url": "",
+                },
+                {
+                    "softwareType": "apt",
+                    "name": "sudo",
+                    "version": "1.9.13p3-1+deb12u1",
+                    "url": "",
+                },
+                {
+                    "softwareType": "apt",
+                    "name": "tedge",
+                    "version": "1.1.2~154+gc1df00f",
+                    "url": "",
+                },
+                {
+                    "softwareType": "apt",
+                    "name": "tedge-agent",
+                    "version": "1.1.2~154+gc1df00f",
+                    "url": "",
+                },
+                {
+                    "softwareType": "apt",
+                    "name": "tedge-apt-plugin",
+                    "version": "1.1.2~154+gc1df00f",
+                    "url": "",
+                },
+                {
+                    "softwareType": "apt",
+                    "name": "tedge-mapper",
+                    "version": "1.1.2~154+gc1df00f",
+                    "url": "",
+                },
+                {
+                    "softwareType": "apt",
+                    "name": "tedge-watchdog",
+                    "version": "1.1.2~154+gc1df00f",
+                    "url": "",
+                },
+                {
+                    "softwareType": "apt",
+                    "name": "vim-common",
+                    "version": "2:9.0.1378-2",
+                    "url": "",
+                },
+                {
+                    "softwareType": "apt",
+                    "name": "vim-tiny",
+                    "version": "2:9.0.1378-2",
+                    "url": "",
+                },
+                {
+                    "softwareType": "apt",
+                    "name": "wget",
+                    "version": "1.21.3-1+b1",
+                    "url": "",
+                },
+            ],
+            "c8y_SupportedLogs": ["software-management"],
+            "c8y_SupportedConfigurations": [
+                "/etc/tedge/tedge.toml",
+                "system.toml",
+                "tedge-configuration-plugin",
+            ],
+        }
+        assert compare_dataclass(mo, {"c8y_Availability": {"status": "AVAILABLE"}})
+        assert not compare_dataclass(
+            mo, {"c8y_Availability": {"status": "UNAVAILABLE"}}
+        )
+        assert compare_dataclass(
+            mo,
+            {
+                "type": "thin-edge.io",
+                "c8y_Agent": {
+                    "name": "thin-edge.io",
+                    "version": re.compile("^1.1.2.+"),
+                },
+            },
+        )
+        assert compare_dataclass(
+            mo,
+            {
+                "c8y_SupportedConfigurations": [
+                    "/etc/tedge/tedge.toml",
+                    "system.toml",
+                    "tedge-configuration-plugin",
+                ],
+            },
+        )
+
+        # out of order array
+        assert not compare_dataclass(
+            mo,
+            {
+                "c8y_SupportedConfigurations": [
+                    "system.toml",
+                    "/etc/tedge/tedge.toml",
+                    "tedge-configuration-plugin",
+                ],
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fix a bug where partition inventory object comparisons would fail.

The inventory value assertion now also checks for at least 1 property otherwise it will also fail. This will prevent the assertion from failing silently.