### PR TITLE
fix usage of pop to avoid throwing an exception when the key does not exist

### DIFF
--- a/c8y_test_core/assert_operations.py
+++ b/c8y_test_core/assert_operations.py
@@ -79,7 +79,7 @@ class AssertOperations:
         is a problem with the agent, so it is good practice to run this assertion when testing
         Cumulocity IoT agents.
         """
-        kwargs.pop("status")
+        kwargs.pop("status", None)
         self.assert_count(
             min_count=0, max_count=0, device_id=device_id, status="PENDING", **kwargs
         )

--- a/c8y_test_core/retry.py
+++ b/c8y_test_core/retry.py
@@ -24,8 +24,8 @@ def strip_retry_parameters(options: Dict[str, Any]) -> Dict[str, Any]:
     to the retry mechanism
     """
     output = options.copy()
-    output.pop("timeout")
-    output.pop("wait")
+    output.pop("timeout", None)
+    output.pop("wait", None)
     return output
 
 


### PR DESCRIPTION
Set default value when popping/deleting a key from the dictionary to avoid an exception