### PR TITLE
feat: Add device registration methods

### DIFF
--- a/c8y_test_core/assert_device_registration.py
+++ b/c8y_test_core/assert_device_registration.py
@@ -1,0 +1,120 @@
+"""Device registration assertions and actions"""
+import logging
+import secrets
+import time
+from dataclasses import dataclass
+from typing import Optional
+from c8y_test_core.assert_device import AssertDevice
+from c8y_test_core.utils import to_csv
+
+
+@dataclass
+class DeviceCredentials:
+    """Device credentials"""
+
+    username: str
+    password: str
+
+
+log = logging.getLogger()
+
+
+class AssertDeviceRegistration(AssertDevice):
+    """Assertions"""
+
+    def bulk_register_with_basic_auth(
+        self,
+        external_id: str,
+        external_type: Optional[str] = "c8y_Serial",
+        name: Optional[str] = None,
+        device_type: Optional[str] = "thin-edge.io",
+        **kwargs,
+    ) -> DeviceCredentials:
+        """Bulk device registration for device that require
+        non-cert based authentication (e.g. basic auth)
+
+        Arguments:
+            external_id (str): External id
+            external_type (str): External type. Defaults to c8y_Serial
+            name (Optional[str]): Name of the device. Defaults to the external_id
+            type (Optional[str]): Type of the device. Defaults to thin-edge.io
+        """
+        name = name or external_id
+        password = secrets.token_urlsafe(14)
+        symbols = "".join([secrets.choice(".$-?@!") for i in range(0, 2)])
+        password = password + symbols
+
+        registration_body = to_csv(
+            [
+                ("ID", [external_id]),
+                ("IDTYPE", [external_type]),
+                ("AUTH_TYPE", ["BASIC"]),
+                ("CREDENTIALS", [password]),
+                ("TYPE", [device_type]),
+                ("NAME", [name]),
+                ("com_cumulocity_model_Agent.active", [True]),
+            ]
+        )
+
+        resp = self.context.client.post_file(
+            "/devicecontrol/bulkNewDeviceRequests",
+            registration_body.encode("utf-8"),
+            accept="application/json",
+        )
+        log.info("Registration response: %s", resp)
+        assert resp["numberOfSuccessful"] == resp["numberOfAll"], (
+            "Failed to register device\n" f"response:\n{resp}"
+        )
+
+        username = f"device_{external_id}"
+        if self.context.client.tenant_id:
+            username = f"{self.context.client.tenant_id}/device_{external_id}"
+
+        return DeviceCredentials(username, password)
+
+    def register_with_basic_auth(self, external_id: str, timeout: float = 60, **kwargs):
+        """Register a single device using the basic auth
+
+        For the registration to work, the device must be polling the
+        POST /devicecontrol/newDeviceRequests/{external_id} endpoint in the background.
+        Once the request is approved by this function, the device will receive
+        platform credentials.
+
+        Arguments:
+            external_id (str): external id of the device to be registered
+            timeout (float): Timeout in seconds. Defaults to 60
+        """
+        resp = self.context.client.post(
+            "/devicecontrol/newDeviceRequests",
+            json={
+                "id": external_id,
+            },
+            accept="application/json",
+        )
+        log.info("Registration response. %s", resp)
+
+        # pylint: disable=broad-exception-caught
+        success = False
+        timeout_at = time.monotonic() + timeout
+        while True:
+            try:
+                resp = self.context.client.put(
+                    f"/devicecontrol/newDeviceRequests/{external_id}",
+                    json={
+                        "status": "ACCEPTED",
+                    },
+                    accept="application/json",
+                    content_type="application/json",
+                )
+                log.info("Registration accepted: %s", resp)
+                success = True
+                break
+            except Exception as ex:
+                log.info(
+                    "Registration accepted failed: response=%s, exception=%s", resp, ex
+                )
+            time.sleep(3)
+            if time.monotonic() > timeout_at:
+                break
+
+        assert success, "Failed to register device"

--- a/c8y_test_core/device_management.py
+++ b/c8y_test_core/device_management.py
@@ -10,6 +10,7 @@ from c8y_test_core.assert_command import Command
 from c8y_test_core.assert_configuration import DeviceConfiguration
 from c8y_test_core.assert_device import AssertDevice
 from c8y_test_core.assert_device_certificate import AssertDeviceCertificate
+from c8y_test_core.assert_device_registration import AssertDeviceRegistration
 from c8y_test_core.assert_alarms import Alarms
 from c8y_test_core.assert_events import Events
 from c8y_test_core.assert_firmware import FirmwareManagement
@@ -38,6 +39,7 @@ class DeviceManagement(AssertDevice):
         self.logs = DeviceLogFile(context)
         self.device_status = AssertDeviceAvailability(context)
         self.trusted_certificates = AssertDeviceCertificate(context)
+        self.registration = AssertDeviceRegistration(context)
         self.alarms = Alarms(context)
         self.events = Events(context)
         self.firmware_management = FirmwareManagement(context)

--- a/c8y_test_core/utils.py
+++ b/c8y_test_core/utils.py
@@ -2,8 +2,7 @@
 from __future__ import annotations
 
 import base64
-import re
-from typing import List, Set, Any
+from typing import List, Set, Any, Tuple
 from unittest.mock import Mock
 
 import randomname
@@ -80,7 +79,7 @@ class RandomNameGenerator:
     def random_name(cls, num: int = 3, sep: str = "_") -> str:
         """Generate a readable random name from joined random words.
         Args:
-            num (int):  number of random words to concactenate
+            num (int):  number of random words to concatenate
             sep (str):  concatenation separator
         Returns:
             The generated name
@@ -117,3 +116,38 @@ def build_auth_string(auth_value: str) -> str:
     that JWT tokens always start with an '{'."""
     auth_type = "BEARER" if auth_value.startswith("ey") else "BASIC"
     return f"{auth_type} {auth_value}"
+
+
+def _to_csv_str(values, delimiter: str = ","):
+    formatted_values = []
+    for v in values:
+        if isinstance(v, bool):
+            formatted_values.append(str(v).lower())
+        elif isinstance(v, (int, float)):
+            formatted_values.append(str(v))
+        else:
+            formatted_values.append(f'"{v}"')
+    return ",".join(formatted_values)
+
+
+def to_csv(items: Tuple[str, List[Any]], delimiter: str = ",") -> str:
+    """Convert items to csv format
+
+    Arguments:
+        items (Tuple[str, List[Any]]): List of items, where the first item
+          in tuple is the column name, and the second is a list of values.
+        delimiter (str): Field delimiter. Defaults to ","
+
+    Returns:
+        str: CSV output
+    """
+    columns = _to_csv_str([item[0] for item in items], delimiter=delimiter)
+
+    data = [item[1] for item in items]
+
+    item_len = len(data[0])
+    data_rows = []
+    for i in range(0, item_len):
+        data_rows.append(_to_csv_str([item[i] for item in data], delimiter=delimiter))
+
+    return "\n".join([columns, *data_rows])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,46 @@
+"""Util tests
+"""
+import unittest
+from c8y_test_core.utils import to_csv
+
+
+class TestCSVConversion(unittest.TestCase):
+    def setUp(self) -> None:
+        return super().setUp()
+
+    def test_csv_single_row(self):
+        output = to_csv(
+            [
+                ("col1", ["hello"]),
+                ("col2", [True]),
+                ("col3", [False]),
+                ("col4", [1.234]),
+            ]
+        )
+
+        expected = """
+"col1","col2","col3","col4"
+"hello",true,false,1.234
+""".strip()
+        assert output == expected
+
+    def test_csv_multiple_rows(self):
+        output = to_csv(
+            [
+                ("col1", ["hello", "again"]),
+                ("col2", [True, False]),
+                ("col3", [False, True]),
+                ("col4", [1.234, 10000001]),
+            ]
+        )
+
+        expected = """
+"col1","col2","col3","col4"
+"hello",true,false,1.234
+"again",false,true,10000001
+""".strip()
+        assert output == expected
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Support registration of BASIC auth devices using two new methods:
* bulk_register_with_basic_auth (for bulk creation with known credentials)
* register_with_basic_auth (for manual registration with platform generated credentials)