### PR TITLE
fix(inventory): managed object relationship type check

### DIFF
--- a/c8y_test_core/assert_inventory.py
+++ b/c8y_test_core/assert_inventory.py
@@ -278,7 +278,7 @@ class AssertInventory(AssertDevice):
             if mo is not None:
                 mo_id = mo.id
             return self.context.client.get(
-                f"/inventory/managedObjects/{mo_id}/childDevices/{child_id}"
+                f"/inventory/managedObjects/{mo_id}/{child_type}/{child_id}"
             )
         except KeyError as ex:
             raise InventoryNotFound from ex


### PR DESCRIPTION
Fix an issue where the childType argument was being ignored